### PR TITLE
chore(build): updating dependabot config prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
   - package-ecosystem: "npm"
     schedule:
       interval: "monthly"
-      # Check for npm updates on Sundays
-      day: "saturday"
+      # Check for npm updates on "day"
+      day: "friday"
     allow:
-      - dependency-type: "production"
+      - dependency-type: "direct"
     directory: "/"
     commit-message:
       # for production deps, prefix commit messages with "fix" (trigger a patch release)


### PR DESCRIPTION
Dependabot dev dependency prefix was fix :/ Example https://github.com/activescott/agentmarkdown/pull/155